### PR TITLE
Fix TypeError for is_valid_reward in SelfRewardDPOConfig

### DIFF
--- a/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
+++ b/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
@@ -658,7 +658,7 @@ class SelfRewardDPOConfig(FinetuneConfig):
     max_seq_len: int = 1024
     rewarding_model: Optional[Module] = None   # defaults to self, but can be an external model, as done in OAIF https://arxiv.org/abs/2402.04792 (renamed "LLM Annotator")
     self_reward_config_keyname: str = 'default'
-    is_valid_reward: Callable[float, bool] = lambda reward: reward >= 0
+    is_valid_reward: Callable[[float], bool] = lambda reward: reward >= 0
     is_valid_reward_pair: Callable[[Tensor, Tensor], bool] = default_is_valid_reward_pair
     pick_paired_rewards_fn: Callable[[Tensor], Tensor] = default_pick_paired_rewards_fn
     dropout: float = 0.1


### PR DESCRIPTION
Thank you for the awesome repository! While experimenting with the codebase, I encountered an issue, and after testing on Colab to rule out local env problems, I found that the issue persisted. The current pull request addresses and resolves the error.


Error details: 
```
   is_valid_reward: Callable[float, bool] = lambda reward: reward >= 0
  File "/opt/conda/lib/python3.10/_collections_abc.py", line 436, in __new__
    raise TypeError(f"Expected a list of types, an ellipsis, "
TypeError: Expected a list of types, an ellipsis, ParamSpec, or Concatenate. Got <class 'float'>
```
