### PR TITLE
add self.

### DIFF
--- a/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
+++ b/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
@@ -506,7 +506,7 @@ class DPODatasetGenerator(Module):
         reward_prompt = repeat(reward_prompt, 'n -> b n', b = self.num_evals_to_average)
 
         reward_prompt = reward_prompt.to(device)
-        self_reward_model = self_reward_model.to(device)
+        self_reward_model = self.self_reward_model.to(device)
 
         reward_responses = sample(
             self_reward_model,


### PR DESCRIPTION
If don't add 'self.' here, you'll get a UnboundLocalError. Because the variable 'self.self_reward_model' is initialized in _'_init__' and 'self_reward_model' is not assigned a value before here. Here the program can only recognize 'self.self_reward_model' and not 'self_reward_model'