### PR TITLE
Solves the problem that some variables are not declared

### DIFF
--- a/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
+++ b/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
@@ -869,7 +869,7 @@ class SelfRewardingTrainer(Module):
                     dpo = model,
                     accelerator = self.accelerator,
                     dataset_generator = self_reward_dataset_generator,
-                    dropout = dropout,
+                    dropout = config.dropout,
                     early_stopper_eval_module = config.early_stopper_eval_module,
                     early_stopper_kwargs = dict(
                         early_stop_checkpoint_folder = f'./early-stop-checkpoint.{dpo_iteration}',


### PR DESCRIPTION
Thank you for the awesome repository!🥰 But sorry, I just found another error.😥 The variable "dropout" is not defined. "dropout" should be "config.dropout". Maybe you forgot to test the case where config is ExternalRewardDPOConfig, the only case where the dropout variable is used incorrectly is this case. Thank you for contributing to the open source community!🤩