### PR TITLE
Fixed deep copy, shallow copy error and label mask error.

### DIFF
--- a/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
+++ b/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
@@ -317,7 +317,7 @@ class SFTTrainer(Module):
 
         seq, labels = seq[:, :-1].clone(), seq[:, 1:].clone()
 
-        labels.masked_fill_(prompt_mask[:, 1:], self.ignore_index)
+        labels.masked_fill_(~prompt_mask[:, 1:], self.ignore_index)
 
         logits = self.model(seq)
 

--- a/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
+++ b/self_rewarding_lm_pytorch/self_rewarding_lm_pytorch.py
@@ -315,7 +315,7 @@ class SFTTrainer(Module):
         else:
             prompt_mask = prompt_len_or_mask
 
-        seq, labels = seq[:, :-1], seq[:, 1:]
+        seq, labels = seq[:, :-1].clone(), seq[:, 1:].clone()
 
         labels.masked_fill_(prompt_mask[:, 1:], self.ignore_index)
 
@@ -822,6 +822,7 @@ class SelfRewardingTrainer(Module):
                     eval_filter_fn = config.eval_filter_fn,
                     eval_filter_kwargs = config.eval_filter_kwargs,
                     accelerator = self.accelerator,
+                    pad_id = pad_id,
                     **config.reward_generator_kwargs
                 )
 
@@ -862,6 +863,7 @@ class SelfRewardingTrainer(Module):
                     eval_temperature = config.eval_temperature,
                     eval_filter_fn = config.eval_filter_fn,
                     eval_filter_kwargs = config.eval_filter_kwargs,
+                    pad_id = pad_id,
                     **config.reward_generator_kwargs
                 )
 


### PR DESCRIPTION
Hi, I'm here again😁
1. On line 318, seq, labels = seq[:, :-1], seq[:, 1:] will cause 'seq' and 'labels' to share the original 'seq''s memory address. This will cause the 'seq' to be masked when the following mask is done on the 'labels', resulting in a token id outside of the vocab in the 'seq', affecting the program's running. So I added '.clone()' to do a deep copy, making 'labels' and 'seq' occupy different memory spaces.
2. In the usual attention_mask, 'True' represents a position that is noticed and 'False' represents, a position that does not want to be noticed. In your function 'prompt_mask_from_len', do the same. But in line 320: labels.masked_fill(prompt_mask[:, 1:], self.ignore_index) causes the positions that are 'True' in prompt_mask to be masked, but the positions that are 'false' not to be masked, contrary to expectations. So I added '~' before 'prompt_mask[:, 1:]' to make the program run as expected
3. To customize the 'pad_id' I wanted I added the 'pad_id' to the class instantiation parameter.